### PR TITLE
fix: dont splice value of customizable indent into indent rules

### DIFF
--- a/vhdl-ts-mode.el
+++ b/vhdl-ts-mode.el
@@ -640,7 +640,7 @@ Matches if point is at a punctuation/operator char, somehow as a fallback."
   `((vhdl
      ;; Comments
      ((and (node-is "comment") (parent-is ,vhdl-ts--indent-zero-parent-node-re)) parent-bol 0)
-     ((node-is "comment") grand-parent ,vhdl-ts-indent-level)
+     ((node-is "comment") grand-parent vhdl-ts-indent-level)
      ;; Zero-indent
      ((node-is "library_clause") parent-bol 0)
      ((node-is "use_clause") parent-bol 0)
@@ -650,44 +650,44 @@ Matches if point is at a punctuation/operator char, somehow as a fallback."
      ((node-is "package_declaration") parent-bol 0)
      ((node-is "package_body") parent-bol 0)
      ;; Generics and ports
-     (vhdl-ts--matcher-generic-or-port grand-parent ,vhdl-ts-indent-level)
-     ((node-is "constant_interface_declaration") parent-bol ,vhdl-ts-indent-level) ; Generic ports
-     ((node-is "signal_interface_declaration") parent-bol ,vhdl-ts-indent-level) ; Signal ports
+     (vhdl-ts--matcher-generic-or-port grand-parent vhdl-ts-indent-level)
+     ((node-is "constant_interface_declaration") parent-bol vhdl-ts-indent-level) ; Generic ports
+     ((node-is "signal_interface_declaration") parent-bol vhdl-ts-indent-level) ; Signal ports
      ;; Declarations
-     ((node-is "declarative_part") parent-bol ,vhdl-ts-indent-level) ; First declaration of the declarative part
-     ((node-is "component_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "signal_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "constant_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "full_type_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "element_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "variable_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "procedure_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "function_declaration") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "function_body") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "procedure_body") grand-parent ,vhdl-ts-indent-level)
+     ((node-is "declarative_part") parent-bol vhdl-ts-indent-level) ; First declaration of the declarative part
+     ((node-is "component_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "signal_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "constant_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "full_type_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "element_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "variable_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "procedure_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "function_declaration") grand-parent vhdl-ts-indent-level)
+     ((node-is "function_body") grand-parent vhdl-ts-indent-level)
+     ((node-is "procedure_body") grand-parent vhdl-ts-indent-level)
      ;; Concurrent & generate
-     ((node-is "concurrent_statement_part") parent-bol ,vhdl-ts-indent-level) ; First signal declaration of a declarative part
-     ((node-is "generate_statement_body") parent-bol ,vhdl-ts-indent-level)
-     ((node-is "for_generate_statement") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "if_generate_statement") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "simple_concurrent_signal_assignment") vhdl-ts--anchor-concurrent-signal-assignment ,vhdl-ts-indent-level) ; Parent is (concurrent_statement_part)
-     ((node-is "conditional_concurrent_signal_assignment") vhdl-ts--anchor-concurrent-signal-assignment ,vhdl-ts-indent-level)
-     ((node-is "alternative_conditional_waveforms") parent-bol ,vhdl-ts-indent-level) ; Each of the else clases in conditional concurrent assignment
-     ((node-is "process_statement") grand-parent ,vhdl-ts-indent-level) ; Grandparent is architecture_body
+     ((node-is "concurrent_statement_part") parent-bol vhdl-ts-indent-level) ; First signal declaration of a declarative part
+     ((node-is "generate_statement_body") parent-bol vhdl-ts-indent-level)
+     ((node-is "for_generate_statement") grand-parent vhdl-ts-indent-level)
+     ((node-is "if_generate_statement") grand-parent vhdl-ts-indent-level)
+     ((node-is "simple_concurrent_signal_assignment") vhdl-ts--anchor-concurrent-signal-assignment vhdl-ts-indent-level) ; Parent is (concurrent_statement_part)
+     ((node-is "conditional_concurrent_signal_assignment") vhdl-ts--anchor-concurrent-signal-assignment vhdl-ts-indent-level)
+     ((node-is "alternative_conditional_waveforms") parent-bol vhdl-ts-indent-level) ; Each of the else clases in conditional concurrent assignment
+     ((node-is "process_statement") grand-parent vhdl-ts-indent-level) ; Grandparent is architecture_body
      ;; Instances
-     ((node-is "component_instantiation_statement") grand-parent ,vhdl-ts-indent-level)
+     ((node-is "component_instantiation_statement") grand-parent vhdl-ts-indent-level)
      ((node-is "component_map_aspect") grand-parent 0) ; Generic map if present, otherwise port map
      ((node-is "port_map_aspect") parent-bol 0) ; Port map only when there are generics
-     ((node-is "association_list") vhdl-ts--anchor-instance-port ,vhdl-ts-indent-level)
+     ((node-is "association_list") vhdl-ts--anchor-instance-port vhdl-ts-indent-level)
      ((node-is "named_association_element") parent-bol 0)
      ;; Procedural
-     ((node-is "sequence_of_statements") parent-bol ,vhdl-ts-indent-level) ; Statements inside process
-     ((parent-is "sequence_of_statements") grand-parent ,vhdl-ts-indent-level)
+     ((node-is "sequence_of_statements") parent-bol vhdl-ts-indent-level) ; Statements inside process
+     ((parent-is "sequence_of_statements") grand-parent vhdl-ts-indent-level)
      ((or (node-is "if") (node-is "else") (node-is "elsif")) parent-bol 0)
-     ((node-is "case_statement") grand-parent ,vhdl-ts-indent-level)
-     ((node-is "case_statement_alternative") parent-bol ,vhdl-ts-indent-level)
+     ((node-is "case_statement") grand-parent vhdl-ts-indent-level)
+     ((node-is "case_statement_alternative") parent-bol vhdl-ts-indent-level)
      ;; Others
-     ((node-is "aggregate") grand-parent ,vhdl-ts-indent-level) ; Aggregates/array elements
+     ((node-is "aggregate") grand-parent vhdl-ts-indent-level) ; Aggregates/array elements
      ((node-is "positional_element_association") parent-bol 0)  ; Check test/files/indent/tree-sitter/indent_misc.vhd:42
      ;; Opening & closing
      ((node-is "begin") parent-bol 0)
@@ -695,8 +695,8 @@ Matches if point is at a punctuation/operator char, somehow as a fallback."
      ((node-is ")") parent-bol 0)
      ;; Fallbacks/default
      ((and vhdl-ts--matcher-blank-line (parent-is ,vhdl-ts--indent-zero-parent-node-re)) parent-bol 0)
-     (vhdl-ts--matcher-blank-line parent-bol ,vhdl-ts-indent-level) ; Blank lines
-     ((or vhdl-ts--matcher-keyword vhdl-ts--matcher-punctuation) parent-bol ,vhdl-ts-indent-level)
+     (vhdl-ts--matcher-blank-line parent-bol vhdl-ts-indent-level) ; Blank lines
+     ((or vhdl-ts--matcher-keyword vhdl-ts--matcher-punctuation) parent-bol vhdl-ts-indent-level)
      (vhdl-ts--matcher-default parent 0))))
 
 


### PR DESCRIPTION
This removes backquote substitution of `vhdl-ts-indent-level` into `vhdl-ts--indent-rules` 
so changes to `vhdl-ts-indent-level` have effect without needing to re-evaluate
`vhdl-ts--indent-rules`.