### PR TITLE
Indentation changes, more similar to `vhdl-mode`, bugfixes

### DIFF
--- a/vhdl-ts-mode.el
+++ b/vhdl-ts-mode.el
@@ -655,10 +655,11 @@ Matches if point is at a punctuation/operator char, somehow as a fallback."
      ((node-is "architecture_body") parent-bol 0)
      ((node-is "package_declaration") parent-bol 0)
      ((node-is "package_body") parent-bol 0)
-     ;; Generics and ports
+     ;; Procedure parameter types
      (vhdl-ts--matcher-generic-or-port grand-parent vhdl-ts-indent-level)
-     ((node-is "constant_interface_declaration") parent-bol vhdl-ts-indent-level) ; Generic ports
-     ((node-is "signal_interface_declaration") parent-bol vhdl-ts-indent-level) ; Signal ports
+     ((node-is "constant_interface_declaration") parent-bol vhdl-ts-indent-level) ; Constant parameter
+     ((node-is "variable_interface_declaration") parent-bol vhdl-ts-indent-level) ; Variable parameter
+     ((node-is "signal_interface_declaration") parent-bol vhdl-ts-indent-level) ; Signal parameter
      ;; Declarations
      ((node-is "declarative_part") parent-bol vhdl-ts-indent-level) ; First declaration of the declarative part
      ((node-is "component_declaration") grand-parent vhdl-ts-indent-level)
@@ -682,13 +683,22 @@ Matches if point is at a punctuation/operator char, somehow as a fallback."
      ((node-is "if_generate_statement") grand-parent vhdl-ts-indent-level)
      ((node-is "simple_concurrent_signal_assignment") vhdl-ts--anchor-concurrent-signal-assignment vhdl-ts-indent-level) ; Parent is (concurrent_statement_part)
      ((node-is "conditional_concurrent_signal_assignment") vhdl-ts--anchor-concurrent-signal-assignment vhdl-ts-indent-level)
-     ((node-is "alternative_conditional_waveforms") parent-bol vhdl-ts-indent-level) ; Each of the else clases in conditional concurrent assignment
+     ((and
+       (node-is "waveforms")
+       (or
+        (parent-is "alternative_conditional_waveforms")
+        (parent-is "alternative_selected_waveforms")))
+      grand-parent 0) ; when else on next line or select multiple lines
      ((node-is "process_statement") grand-parent vhdl-ts-indent-level) ; Grandparent is architecture_body
+     ((node-is "selected_waveforms") parent-bol vhdl-ts-indent-level)
+     ((and (node-is "simple_name")
+           (parent-is "selected_concurrent_signal_assignment"))
+      parent-bol vhdl-ts-indent-level)
      ;; Instances
      ((node-is "component_instantiation_statement") grand-parent vhdl-ts-indent-level)
-     ((node-is "component_map_aspect") grand-parent 0) ; Generic map if present, otherwise port map
+     ((node-is "component_map_aspect") grand-parent vhdl-ts-indent-level) ; Generic map if present, otherwise port map
      ((node-is "port_map_aspect") parent-bol 0) ; Port map only when there are generics
-     ((node-is "association_list") vhdl-ts--anchor-instance-port vhdl-ts-indent-level)
+     ((node-is "association_list") parent-bol vhdl-ts-indent-level)
      ((node-is "named_association_element") parent-bol 0)
      ;; Procedural
      ((node-is "sequence_of_statements") parent-bol vhdl-ts-indent-level) ; Statements inside process
@@ -708,7 +718,6 @@ Matches if point is at a punctuation/operator char, somehow as a fallback."
      (vhdl-ts--matcher-blank-line parent-bol vhdl-ts-indent-level) ; Blank lines
      ((or vhdl-ts--matcher-keyword vhdl-ts--matcher-punctuation) parent-bol vhdl-ts-indent-level)
      (vhdl-ts--matcher-default parent 0))))
-
 
 ;;; Imenu
 (defconst vhdl-ts-imenu-create-index-re


### PR DESCRIPTION
Hello,

when using `vhdl-ts-mode` I noticed some problems with indentation. This PR addresses them. I am not really sure what the intention of this mode is, and whether it should be more similar to vhdl-mode or not. There are two parts to this PR. I think one part should be merged, and the other one is probably more opinionated, and I am not sure you will want to merge it. 

# First part (bugs)
1. `variable_interface_declaration` is missing, leading to variable being indented improperly in `procedure` declaration, see
```vhdl
  procedure trigger_scl_pulse(
                             variable asdf      : in    test;
    signal scl_rising  : inout std_logic;
    signal scl_falling : inout std_logic
  ) is
``` 
2. `when else` with `else` being on one line, and alternative assignment being on the next line, is aligned to start of `else`, instead of start of `<=`. This was reported in #6.
3. Empty lines are indented by `vhdl-ts-indent-offset`, sometimes leading to situations where empty line has different indent then when something ends up being on the line.

# Second part (opinionated changes for more similarity to vhdl-mode)
1. `port map` and `generic map` are on the same level as first `label: entity` line, instead of indented more deeply, to indicate they are structurally under that entity.
2. `else` with `when` block is aligned one level from `assignment <=` instead of after `<=`, like vhdl mode has it

# Demonstration
## Before
```vhdl
library ieee;
use ieee.std_logic_1164.all;

entity indent_test is

end entity indent_test;

architecture testarchitect of indent_test is
  function asdf (
    constant test : test)
    return trest is
  begin  -- function asdf
    -- empty line alignment
  end function asdf;

    -- empty line alignment

  procedure my_procedure (
    constant const : in std_logic;
                         variable var : in std_logic);
  -- empty line alignment
begin  -- architecture testarchitect

  -- empty line alignment

  label: entity work.my_entity
  port map (
    test => test);

  NSL : state_next <= RED_YELLOW when state_reg = RED and button = '1' else
                                                                       GREEN  when state_reg = RED_YELLOW
    else YELLOW when state_reg = GREEN and button = '1' else
                                                        RED when state_reg = YELLOW else
                                                                                    state_reg;
    -- this line has been typed without aligning it afterwards, only aligning
    -- it prior to typing when it was emtpy

  -- this is after beautify

  OL : with state_reg select
  leds <=
  "100" when RED,
                "110" when RED_YELLOW,
                                     "001" when GREEN,
                                                     "010" when YELLOW,
                                                                      "---" when others;
  -- empty line alignment

end architecture testarchitect;

```

## After
```vhdl
library ieee;
use ieee.std_logic_1164.all;

entity indent_test is

end entity indent_test;

architecture testarchitect of indent_test is
  -- empty line alignment

  function asdf (
    constant test : test)
    return trest is
  begin  -- function asdf
    -- empty line alignment
  end function asdf;

  -- empty line alignment

  procedure my_procedure (
    constant const : in std_logic;
    variable var : in std_logic);

  -- empty line alignment
begin  -- architecture testarchitec

  -- empty line alignment

  label: entity work.my_entity
    port map (
      test => test);

  NSL : state_next <= RED_YELLOW when state_reg = RED and button = '1' else
                      GREEN  when state_reg = RED_YELLOW else
                      YELLOW when state_reg = GREEN and button = '1'
                      else RED when state_reg = YELLOW else
                      state_reg;

  -- this line has been typed without aligning it afterwards, only aligning
  -- it prior to typing when it was emtpy

  OL : with state_reg select
  leds <=
    "100" when RED,
    "110" when RED_YELLOW,
    "001" when GREEN,
    "010" when YELLOW,
    "---" when others;


  -- empty line alignment


end architecture testarchitect;
```